### PR TITLE
Fetching L1TMuonEndCapForests from the EventSetup

### DIFF
--- a/CondCore/L1TPlugins/src/UpgradeRecords2.cc
+++ b/CondCore/L1TPlugins/src/UpgradeRecords2.cc
@@ -2,6 +2,8 @@
 #include "CondFormats/L1TObjects/interface/L1TMuonEndCapParams.h"
 #include "CondFormats/DataRecord/interface/L1TMuonEndcapParamsRcd.h"
 #include "CondFormats/DataRecord/interface/L1TMuonEndcapParamsO2ORcd.h"
+#include "CondFormats/L1TObjects/interface/L1TMuonEndCapForest.h"
+#include "CondFormats/DataRecord/interface/L1TMuonEndCapForestRcd.h"
 
 #include "CondFormats/L1TObjects/interface/L1TMuonOverlapParams.h"
 #include "CondFormats/DataRecord/interface/L1TMuonOverlapParamsRcd.h"
@@ -16,6 +18,7 @@
 #include "CondFormats/DataRecord/interface/L1TMuonGlobalParamsO2ORcd.h"
 
 REGISTER_PLUGIN(L1TMuonEndcapParamsRcd,  L1TMuonEndCapParams);
+REGISTER_PLUGIN(L1TMuonEndCapForestRcd,  L1TMuonEndCapForest);
 REGISTER_PLUGIN(L1TMuonOverlapParamsRcd, L1TMuonOverlapParams);
 REGISTER_PLUGIN(L1TMuonBarrelParamsRcd, L1TMuonBarrelParams);
 REGISTER_PLUGIN(L1TMuonGlobalParamsRcd, L1TMuonGlobalParams);

--- a/L1Trigger/L1TMuonEndCap/interface/PtAssignmentEngine.hh
+++ b/L1Trigger/L1TMuonEndCap/interface/PtAssignmentEngine.hh
@@ -22,6 +22,9 @@ public:
   typedef uint64_t address_t;
 
   void read(const std::string& xml_dir);
+  void load(const L1TMuonEndCapForest *payload);
+  const std::array<emtf::Forest, 16>& getForests(void) const { return forests_; }
+  const std::vector<int>& getAllowedModes(void) const { return allowedModes_; }
 
   void configure(
       int verbose,

--- a/L1Trigger/L1TMuonEndCap/interface/SectorProcessor.hh
+++ b/L1Trigger/L1TMuonEndCap/interface/SectorProcessor.hh
@@ -25,6 +25,8 @@ public:
   explicit SectorProcessor();
   ~SectorProcessor();
 
+  void resetPtAssignment(const PtAssignmentEngine* new_pt_assign_engine);
+
   typedef unsigned long long EventNumber_t;
   typedef PatternRecognition::pattern_ref_t pattern_ref_t;
 

--- a/L1Trigger/L1TMuonEndCap/interface/TrackFinder.hh
+++ b/L1Trigger/L1TMuonEndCap/interface/TrackFinder.hh
@@ -21,6 +21,8 @@ public:
   explicit TrackFinder(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iConsumes);
   ~TrackFinder();
 
+  void resetPtLUT(std::shared_ptr<const L1TMuonEndCapForest> ptLUT);
+
   void process(
       // Input
       const edm::Event& iEvent, const edm::EventSetup& iSetup,

--- a/L1Trigger/L1TMuonEndCap/interface/bdt/Forest.h
+++ b/L1Trigger/L1TMuonEndCap/interface/bdt/Forest.h
@@ -5,6 +5,7 @@
 
 #include "Tree.h"
 #include "LossFunctions.h"
+#include "CondFormats/L1TObjects/interface/L1TMuonEndCapForest.h"
 
 namespace emtf {
 
@@ -16,6 +17,10 @@ class Forest
         Forest();
         Forest(std::vector<Event*>& trainingEvents);
         ~Forest();
+
+        Forest(const Forest &forest);
+        Forest& operator=(const Forest &forest);
+        Forest(Forest && forest) = default;
 
         // Get/Set
         void setTrainingEvents(std::vector<Event*>& trainingEvents);
@@ -35,6 +40,7 @@ class Forest
         void sortEventVectors(std::vector< std::vector<Event*> >& e);
         void generate(Int_t numTrainEvents, Int_t numTestEvents, double sigma);
         void loadForestFromXML(const char* directory, unsigned int numTrees); 
+        void loadFromCondPayload(const L1TMuonEndCapForest::DForest& payload);
 
         // Perform the regression
         void updateRegTargets(Tree *tree, double learningRate, LossFunction* l);

--- a/L1Trigger/L1TMuonEndCap/interface/bdt/Node.h
+++ b/L1Trigger/L1TMuonEndCap/interface/bdt/Node.h
@@ -16,6 +16,8 @@ class Node
         Node(std::string cName);
         ~Node();
 
+        Node(Node &&) = default;
+
         std::string getName();
         void setName(std::string sName);
 
@@ -59,6 +61,9 @@ class Node
         void theMiracleOfChildBirth();
  
     private:
+        Node(const Node &);
+        Node& operator=(const Node &);
+
 	std::string name;
 
         Node *leftDaughter;

--- a/L1Trigger/L1TMuonEndCap/interface/bdt/Tree.h
+++ b/L1Trigger/L1TMuonEndCap/interface/bdt/Tree.h
@@ -10,6 +10,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CondFormats/L1TObjects/interface/L1TMuonEndCapForest.h"
 
 namespace emtf {
 
@@ -21,6 +22,10 @@ class Tree
         Tree();
         Tree(std::vector< std::vector<Event*> >& cEvents);
         ~Tree();
+
+        Tree(const Tree &tree);
+        Tree& operator=(const Tree &tree);
+        Tree(Tree && tree);
 
         void setRootNode(Node *sRootNode);
         Node* getRootNode();
@@ -43,6 +48,8 @@ class Tree
 
         void loadFromXML(const char* filename);
         void loadFromXMLRecursive(TXMLEngine* xml, XMLNodePointer_t node, Node* tnode);
+        void loadFromCondPayload(const L1TMuonEndCapForest::DTree& tree);
+        void loadFromCondPayloadRecursive(const L1TMuonEndCapForest::DTree& tree, const L1TMuonEndCapForest::DTreeNode& node, Node* tnode);
 
         void rankVariables(std::vector<Double_t>& v);
         void rankVariablesRecursive(Node* node, std::vector<Double_t>& v);
@@ -55,6 +62,11 @@ class Tree
         std::list<Node*> terminalNodes;
         Int_t numTerminalNodes;
         Double_t rmsError;
+
+        // this is the main recursive workhorse function that compensates for Nodes being non-copyable
+        Node* copyFrom(const Node *local_root); // no garantees if throws in the process
+        // a dumb DFS tree traversal
+        void findLeafs(Node *local_root, std::list<Node*> &tn);
 };
 
 } // end of emtf namespace

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapForestESProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapForestESProducer.cc
@@ -1,0 +1,113 @@
+#include <iostream>
+#include <memory>
+#include <iostream>
+
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESProducts.h"
+
+#include "CondFormats/L1TObjects/interface/L1TMuonEndCapForest.h"
+#include "CondFormats/DataRecord/interface/L1TMuonEndCapForestRcd.h"
+
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+
+#include "L1Trigger/L1TMuonEndCap/interface/PtAssignmentEngine.hh"
+#include "L1Trigger/L1TMuonEndCap/interface/bdt/Node.h"
+#include "L1Trigger/L1TMuonEndCap/interface/bdt/Tree.h"
+#include "L1Trigger/L1TMuonEndCap/interface/bdt/Forest.h"
+
+using namespace std;
+
+// class declaration
+
+class L1TMuonEndCapForestESProducer : public edm::ESProducer {
+private:
+  string bdtXMLDir;
+
+  L1TMuonEndCapForest::DTree traverse(emtf::Node* tree);
+
+public:
+  L1TMuonEndCapForestESProducer(const edm::ParameterSet&);
+  ~L1TMuonEndCapForestESProducer(){}
+  
+  typedef std::shared_ptr<L1TMuonEndCapForest> ReturnType;
+
+  ReturnType produce(const L1TMuonEndCapForestRcd&);
+};
+
+L1TMuonEndCapForestESProducer::L1TMuonEndCapForestESProducer(const edm::ParameterSet& iConfig)
+{
+   setWhatProduced(this);
+   bdtXMLDir = iConfig.getParameter<string>("bdtXMLDir");
+}
+
+L1TMuonEndCapForest::DTree L1TMuonEndCapForestESProducer::traverse(emtf::Node* node){
+    // original implementation use 0 ptr for non-existing children nodes, return empty cond tree (vector of nodes)
+    if( !node ) return L1TMuonEndCapForest::DTree();
+    // recur on left and then right child
+    L1TMuonEndCapForest::DTree left_subtree  = traverse( node->getLeftDaughter() );
+    L1TMuonEndCapForest::DTree right_subtree = traverse( node->getRightDaughter() );
+    // allocate tree
+    L1TMuonEndCapForest::DTree cond_tree(1 + left_subtree.size() + right_subtree.size());
+    // copy the local root node
+    L1TMuonEndCapForest::DTreeNode &local_root = cond_tree[0]; 
+    local_root.splitVar = node->getSplitVariable();
+    local_root.splitVal = node->getSplitValue(); 
+    local_root.fitVal   = node->getFitValue();
+    // shift children indicies and place the subtrees into the newly allocated tree
+    local_root.ileft    = (left_subtree.size()?1:0); // left subtree (if exists) is placed right after the root -> index=1
+    transform(left_subtree.cbegin(), // source from
+              left_subtree.cend(),   // source till
+              cond_tree.begin() + 1, // destination
+              [] (L1TMuonEndCapForest::DTreeNode cond_node) {
+                     // increment indecies only for existing children, left 0 for non-existing
+                     if( cond_node.ileft ) cond_node.ileft  += 1;
+                     if( cond_node.iright) cond_node.iright += 1;
+                     return cond_node;
+              }
+    );
+    unsigned int offset = left_subtree.size();
+    local_root.iright = (offset+right_subtree.size() ? 1 + offset : 0); // right subtree is placed after the left one
+    transform(right_subtree.cbegin(), // source from
+              right_subtree.cend(),   // source till
+              cond_tree.begin() + 1 + offset, // destination
+              [offset] (L1TMuonEndCapForest::DTreeNode cond_node) {
+                     // increment indecies only for existing children, left 0 for non-existing
+                     if( cond_node.ileft ) cond_node.ileft  += 1 + offset;
+                     if( cond_node.iright) cond_node.iright += 1 + offset;
+                     return cond_node;
+              }
+    );
+    return cond_tree;
+}
+
+L1TMuonEndCapForestESProducer::ReturnType
+L1TMuonEndCapForestESProducer::produce(const L1TMuonEndCapForestRcd& iRecord)
+{
+   // piggiback on the PtAssignmentEngine class to read the XMLs in
+   PtAssignmentEngine pt_assign_engine_;
+   pt_assign_engine_.read(bdtXMLDir);
+   // get a hold on the forests; copy to non-const locals
+   std::array<emtf::Forest, 16> forests = pt_assign_engine_.getForests();
+   std::vector<int> allowedModes = pt_assign_engine_.getAllowedModes();
+   // construct empty cond payload
+   std::shared_ptr<L1TMuonEndCapForest> pEMTFForest(new L1TMuonEndCapForest());
+   // pack the forests into the cond payload for each mode
+   pEMTFForest->forest_coll_.resize(0);
+   for(unsigned int i=0; i<allowedModes.size(); i++){
+       int mode = allowedModes[i];
+       pEMTFForest->forest_map_[mode] = i;
+       // convert emtf::Forest into the L1TMuonEndCapForest::DForest
+       emtf::Forest& forest = forests.at(mode);
+       L1TMuonEndCapForest::DForest cond_forest;
+       for(unsigned int j=0; j<forest.size(); j++)
+           cond_forest.push_back( traverse( forest.getTree(j)->getRootNode() ) );
+       // of course, move has no effect here, but I'll keep it in case move constructor will be provided some day
+       pEMTFForest->forest_coll_.push_back( std::move( cond_forest ) );
+   }
+
+   return pEMTFForest;
+}
+
+DEFINE_FWK_EVENTSETUP_MODULE(L1TMuonEndCapForestESProducer);

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
@@ -33,7 +33,7 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& iEvent, const edm::EventSet
       // with the magic above you can use params->fwVersion to change emulator's behavior
       // ...
       // reset cache id
-      ptLutCacheID = iSetup.get<L1TMuonEndcapParamsRcd>().cacheIdentifier();
+      paramsCacheID = iSetup.get<L1TMuonEndcapParamsRcd>().cacheIdentifier();
   }
 
   // Pull pt LUT from the EventSetup if we suspect it has changed

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
@@ -3,6 +3,9 @@
 #include "CondFormats/L1TObjects/interface/L1TMuonEndCapParams.h"
 #include "CondFormats/DataRecord/interface/L1TMuonEndcapParamsRcd.h"
 
+#include "CondFormats/L1TObjects/interface/L1TMuonEndCapForest.h"
+#include "CondFormats/DataRecord/interface/L1TMuonEndCapForestRcd.h"
+
 L1TMuonEndCapTrackProducer::L1TMuonEndCapTrackProducer(const edm::ParameterSet& iConfig) :
     track_finder_(new TrackFinder(iConfig, consumesCollector())),
     uGMT_converter_(new MicroGMTConverter()),
@@ -23,8 +26,15 @@ void L1TMuonEndCapTrackProducer::produce(edm::Event& iEvent, const edm::EventSet
   // Pull configuration from the EventSetup
   edm::ESHandle<L1TMuonEndCapParams> handle;
   iSetup.get<L1TMuonEndcapParamsRcd>().get( handle ) ;
-  std::shared_ptr<L1TMuonEndCapParams> params(new L1TMuonEndCapParams(*(handle.product ())));
+  std::shared_ptr<L1TMuonEndCapParams> params(new L1TMuonEndCapParams(*(handle.product())));
   // with the magic above you can use params->fwVersion to change emulator's behavior
+
+  // Pull pt LUT from the EventSetup
+  edm::ESHandle<L1TMuonEndCapForest> handle2;
+  iSetup.get<L1TMuonEndCapForestRcd>().get( handle2 ) ;
+  std::shared_ptr<L1TMuonEndCapForest> ptLUT(new L1TMuonEndCapForest(*(handle2.product())));
+  // at that point we want to re-initialize the track_finder_ object with the newly pulled ptLUT
+  track_finder_->resetPtLUT( std::const_pointer_cast<const L1TMuonEndCapForest>(ptLUT) );
 
   // Create pointers to output products
   auto out_hits   = std::make_unique<EMTFHitCollection>();

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.h
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.h
@@ -39,6 +39,9 @@ private:
   std::unique_ptr<MicroGMTConverter> uGMT_converter_;
 
   const edm::ParameterSet& config_;
+
+  unsigned long long paramsCacheID;
+  unsigned long long ptLutCacheID;
 };
 
 #endif

--- a/L1Trigger/L1TMuonEndCap/python/fakeEmtfParams_cff.py
+++ b/L1Trigger/L1TMuonEndCap/python/fakeEmtfParams_cff.py
@@ -20,14 +20,15 @@ emtfParams = cms.ESProducer(
 
 
 
-# emtfForestsSource = cms.ESSource(
-# 	"EmptyESSource",
-# 	recordName = cms.string('L1TMuonEndCapForestRcd'),
-# 	iovIsRunNotTime = cms.bool(True),
-# 	firstValid = cms.vuint32(1)
-# )
+emtfForestsSource = cms.ESSource(
+	"EmptyESSource",
+	recordName = cms.string('L1TMuonEndCapForestRcd'),
+	iovIsRunNotTime = cms.bool(True),
+	firstValid = cms.vuint32(1)
+)
 
-# ##EMTF ESProducer. Fills CondFormats from XML files.
-# emtfForests = cms.ESProducer(
-# 	"L1TMuonEndCapForestESProducer",
-# )
+##EMTF ESProducer. Fills CondFormats from XML files.
+emtfForests = cms.ESProducer(
+	"L1TMuonEndCapForestESProducer",
+        bdtXMLDir = cms.string('v_16_02_21')
+)

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngine.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngine.cc
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <iostream>
+#include <sstream>
 
 
 PtAssignmentEngine::PtAssignmentEngine() :
@@ -32,6 +33,28 @@ void PtAssignmentEngine::read(const std::string& xml_dir) {
 
   ok_ = true;
   return;
+}
+
+void PtAssignmentEngine::load(const L1TMuonEndCapForest *payload){
+
+  for (unsigned i=0;i<allowedModes_.size();i++){
+    int mode_inv = allowedModes_.at(i);
+
+    L1TMuonEndCapForest::DForestMap::const_iterator index = payload->forest_map_.find(mode_inv); // associates mode to index 
+
+    if( index == payload->forest_map_.end() ) continue;
+
+    forests_.at(mode_inv).loadFromCondPayload( payload->forest_coll_[index->second] );
+
+//    for(int t=0; t<64; t++){
+//        emtf::Tree* tree = forests_.at( mode_inv ).getTree(t);
+//        std::stringstream ss;
+//        ss << mode_inv << "/" << t << ".xml";
+//        tree->saveToXML( ss.str().c_str() );
+//    }
+
+  }
+
 }
 
 void PtAssignmentEngine::configure(

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessor.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessor.cc
@@ -9,6 +9,11 @@ SectorProcessor::~SectorProcessor() {
 
 }
 
+void SectorProcessor::resetPtAssignment(const PtAssignmentEngine* new_pt_assign_engine){
+  pt_assign_engine_ = new_pt_assign_engine;
+  readPtLUTFile_ = false;
+}
+
 void SectorProcessor::configure(
     const L1TMuon::GeometryTranslator* tp_geom,
     const SectorProcessorLUT* lut,

--- a/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
+++ b/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
@@ -96,6 +96,21 @@ TrackFinder::TrackFinder(const edm::ParameterSet& iConfig, edm::ConsumesCollecto
   }
 }
 
+void TrackFinder::resetPtLUT(std::shared_ptr<const L1TMuonEndCapForest> ptLUT){
+
+    pt_assign_engine_.load(ptLUT.get());
+
+    // Configure sector processors
+    for (int endcap = MIN_ENDCAP; endcap <= MAX_ENDCAP; ++endcap) {
+      for (int sector = MIN_TRIGSECTOR; sector <= MAX_TRIGSECTOR; ++sector) {
+        const int es = (endcap - MIN_ENDCAP) * (MAX_TRIGSECTOR - MIN_TRIGSECTOR + 1) + (sector - MIN_TRIGSECTOR);
+
+        sector_processors_.at(es).resetPtAssignment(&pt_assign_engine_);
+
+      }
+    }
+}
+
 TrackFinder::~TrackFinder() {
 
 }

--- a/L1Trigger/L1TMuonEndCap/src/bdt/Forest.cc
+++ b/L1Trigger/L1TMuonEndCap/src/bdt/Forest.cc
@@ -61,7 +61,7 @@ Forest::~Forest()
 
     for(unsigned int i=0; i < trees.size(); i++)
     { 
-        delete trees[i];
+        if(trees[i]) delete trees[i];
     }
 }
 
@@ -539,6 +539,10 @@ void Forest::loadFromCondPayload(const L1TMuonEndCapForest::DForest& forest)
 // Load a forest that has already been created and stored in CondDB.
     // Initialize the vector of trees.
     unsigned int numTrees = forest.size();
+
+    // clean-up leftovers from previous initialization (if any)
+    for(unsigned int i=0; i < trees.size(); i++)
+        if( trees[i] ) delete trees[i];
 
     trees = std::vector<Tree*>(numTrees);
 

--- a/L1Trigger/L1TMuonEndCap/src/bdt/Forest.cc
+++ b/L1Trigger/L1TMuonEndCap/src/bdt/Forest.cc
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <sstream>
 #include <algorithm>
+#include <iterator>
 #include <fstream>
 #include <utility>
 
@@ -63,6 +64,32 @@ Forest::~Forest()
         delete trees[i];
     }
 }
+
+Forest::Forest(const Forest &forest)
+{
+    transform(forest.trees.cbegin(),
+              forest.trees.cend(),
+              back_inserter(trees),
+              [] (const Tree *tree) { return new Tree(*tree); }
+    );
+}
+
+Forest& Forest::operator=(const Forest &forest)
+{
+    for(unsigned int i=0; i < trees.size(); i++)
+    { 
+        delete trees[i];
+    }
+    trees.resize(0);
+
+    transform(forest.trees.cbegin(),
+              forest.trees.cend(),
+              back_inserter(trees),
+              [] (const Tree *tree) { return new Tree(*tree); }
+    );
+    return *this;
+}
+
 //////////////////////////////////////////////////////////////////////////
 // ______________________Get/Set_Functions______________________________//
 //////////////////////////////////////////////////////////////////////////
@@ -505,6 +532,22 @@ void Forest::loadForestFromXML(const char* directory, unsigned int numTrees)
     }   
 
    // std::cout << "Done." << std::endl << std::endl;
+}
+
+void Forest::loadFromCondPayload(const L1TMuonEndCapForest::DForest& forest)
+{
+// Load a forest that has already been created and stored in CondDB.
+    // Initialize the vector of trees.
+    unsigned int numTrees = forest.size();
+
+    trees = std::vector<Tree*>(numTrees);
+
+    // Load the Forest.
+    for(unsigned int i=0; i < numTrees; i++)
+    {
+        trees[i] = new Tree();
+        trees[i]->loadFromCondPayload(forest[i]);
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/L1Trigger/L1TMuonEndCap/src/bdt/Node.cc
+++ b/L1Trigger/L1TMuonEndCap/src/bdt/Node.cc
@@ -62,8 +62,8 @@ Node::Node(std::string cName)
 Node::~Node()
 {
 // Recursively delete all nodes in the tree.
-    delete leftDaughter;
-    delete rightDaughter;
+    if(leftDaughter)  delete leftDaughter;
+    if(rightDaughter) delete rightDaughter;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/L1Trigger/L1TMuonEndCap/src/bdt/Tree.cc
+++ b/L1Trigger/L1TMuonEndCap/src/bdt/Tree.cc
@@ -51,7 +51,90 @@ Tree::~Tree()
 {
 // When the tree is destroyed it will delete all of the nodes in the tree.
 // The deletion begins with the rootnode and continues recursively.
-    delete rootNode;
+   if(rootNode) delete rootNode;
+}
+
+Tree::Tree(const Tree &tree)
+{
+    // unfortunately, authors of these classes didn't use const qualifiers
+    rootNode = copyFrom(const_cast<Tree&>(tree).getRootNode());
+    numTerminalNodes = tree.numTerminalNodes;
+    rmsError = tree.rmsError;
+
+    terminalNodes.resize(0);
+    // find new leafs
+    findLeafs(rootNode,terminalNodes);
+
+///    if( numTerminalNodes != terminalNodes.size() ) throw std::runtime_error();
+}
+
+Tree& Tree::operator=(const Tree &tree){
+    if(rootNode) delete rootNode;
+    // unfortunately, authors of these classes didn't use const qualifiers
+    rootNode = copyFrom(const_cast<Tree&>(tree).getRootNode());
+    numTerminalNodes = tree.numTerminalNodes;
+    rmsError = tree.rmsError;
+
+    terminalNodes.resize(0);
+    // find new leafs
+    findLeafs(rootNode,terminalNodes);
+
+///    if( numTerminalNodes != terminalNodes.size() ) throw std::runtime_error();
+
+    return *this;
+}
+
+Node* Tree::copyFrom(const Node *local_root)
+{
+    // end-case
+    if( !local_root ) return 0;
+
+    Node *lr = const_cast<Node*>(local_root);
+
+    // recursion
+    Node *left_new_child  = copyFrom( lr->getLeftDaughter()  );
+    Node *right_new_child = copyFrom( lr->getRightDaughter() );
+
+    // performing main work at this level
+    Node *new_local_root  = new Node( lr->getName() );
+    if( left_new_child  ) left_new_child ->setParent(new_local_root);
+    if( right_new_child ) right_new_child->setParent(new_local_root);
+    new_local_root->setLeftDaughter ( left_new_child  );
+    new_local_root->setRightDaughter( right_new_child );
+    new_local_root->setErrorReduction( lr->getErrorReduction() );
+    new_local_root->setSplitValue( lr->getSplitValue() );
+    new_local_root->setSplitVariable( lr->getSplitVariable() );
+    new_local_root->setFitValue( lr->getFitValue() );
+    new_local_root->setTotalError( lr->getTotalError() );
+    new_local_root->setAvgError( lr->getAvgError() );
+    new_local_root->setNumEvents( lr->getNumEvents() );
+//    new_local_root->setEvents( lr->getEvents() ); // no ownership assumed for the events anyways
+
+    return new_local_root;
+}
+
+void Tree::findLeafs(Node *local_root, std::list<Node*> &tn)
+{
+    if( !local_root->getLeftDaughter() && !local_root->getRightDaughter() ){
+        // leaf or ternimal node found
+        tn.push_back(local_root);
+        return;
+    }
+
+    if( local_root->getLeftDaughter() )
+        findLeafs( local_root->getLeftDaughter(), tn );
+
+    if( local_root->getRightDaughter() )
+        findLeafs( local_root->getRightDaughter(), tn );
+}
+
+Tree::Tree(Tree && tree)
+{
+  if(rootNode) delete rootNode; // this line is the only reason not to use default move constructor
+  rootNode = tree.rootNode;
+  terminalNodes = std::move(tree.terminalNodes);
+  numTerminalNodes = tree.numTerminalNodes;
+  rmsError = tree.rmsError;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -464,4 +547,37 @@ void Tree::loadFromXMLRecursive(TXMLEngine* xml, XMLNodePointer_t xnode, Node* t
 
     loadFromXMLRecursive(xml, xleft, tleft);
     loadFromXMLRecursive(xml, xright, tright);
+}
+
+void Tree::loadFromCondPayload(const L1TMuonEndCapForest::DTree& tree)
+{
+    const L1TMuonEndCapForest::DTreeNode& mainnode = tree[0];
+    loadFromCondPayloadRecursive(tree, mainnode, rootNode);
+}
+
+void Tree::loadFromCondPayloadRecursive(const L1TMuonEndCapForest::DTree& tree, const L1TMuonEndCapForest::DTreeNode& node, Node* tnode)
+{
+    // Store gathered splitInfo into the node object.
+    tnode->setSplitVariable(node.splitVar);
+    tnode->setSplitValue(node.splitVal);
+    tnode->setFitValue(node.fitVal);
+
+    // If there are no daughters we are done.
+    if( node.ileft == 0 || node.iright == 0) return; // root cannot be anyone's child
+    if( node.ileft  >= tree.size() ||
+        node.iright >= tree.size() ) return; // out of range addressing on purpose
+
+    // If there are daughters link the node objects appropriately.
+    tnode->theMiracleOfChildBirth();
+    Node* tleft = tnode->getLeftDaughter();
+    Node* tright = tnode->getRightDaughter();
+
+    // Update the list of terminal nodes.
+    terminalNodes.remove(tnode);
+    terminalNodes.push_back(tleft);
+    terminalNodes.push_back(tright);
+    numTerminalNodes++;
+
+    loadFromCondPayloadRecursive(tree, tree[node.ileft], tleft);
+    loadFromCondPayloadRecursive(tree, tree[node.iright], tright);
 }

--- a/L1Trigger/L1TMuonEndCap/src/bdt/Tree.cc
+++ b/L1Trigger/L1TMuonEndCap/src/bdt/Tree.cc
@@ -551,6 +551,10 @@ void Tree::loadFromXMLRecursive(TXMLEngine* xml, XMLNodePointer_t xnode, Node* t
 
 void Tree::loadFromCondPayload(const L1TMuonEndCapForest::DTree& tree)
 {
+    // start fresh in case this is not the only call to construct a tree
+    if( rootNode ) delete rootNode;
+    rootNode = new Node("root");
+
     const L1TMuonEndCapForest::DTreeNode& mainnode = tree[0];
     loadFromCondPayloadRecursive(tree, mainnode, rootNode);
 }


### PR DESCRIPTION
This is the second and last step of integrating the new emulator with the EventSetup/CondDB configuration. It includes following changes:

1) emtf::Tree and emtf::Forest classes own most of their representation by reference. Nonetheless the original version never implemented copy or move constructors thus making impossible to use any of this stuff by value. I had to implement the constructors to add the needed flexibility. Neither of these classes had const qualifiers, but I gave up modifying these and resorted to const_casts where needed.

2) While the original pT LUT forests xml can still be used, the necessary hooks to "reset" the pT LUT were introduced as well as the L1TMuonEndCapForestESProducer class that populates the EventSetup with CondFormat version of these trees.
