### PR TITLE
Fix bug that causes data vs emulator pT mismatch

### DIFF
--- a/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngineAux.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngineAux.cc
@@ -348,8 +348,8 @@ float PtAssignmentEngineAux::getEtaFromThetaInt(int thetaInt, int bits) const {
   thetaInt = (thetaInt > 127) ? 127 : thetaInt;  // 7-bit
   thetaInt = (thetaInt < 0) ? 0 : thetaInt;
   float theta = thetaInt;
-  //theta = (theta*0.2874016 + 8.5)*(3.14159265359/180);
-  theta = (theta*(45.0-8.5)/128. + 8.5) * M_PI/180.;
+  theta = (theta*0.2874016 + 8.5)*(3.14159265359/180);  // use this version to reproduce what happened when the pT LUT was made
+  //theta = (theta*(45.0-8.5)/128. + 8.5) * M_PI/180.;
   float eta = -std::log(std::tan(theta/2));
   return eta;
 }


### PR DESCRIPTION
This PR fixes a bug that I accidentally introduced while I was working on coordinate conversion. The bug causes a pT mismatch when using the XML files vs using the pT LUT file. For them to match, the theta -> eta conversion has to be the same version that was used for generating the pT LUT file.