### PR TITLE
Add 'Era' option, fix compilation issue

### DIFF
--- a/L1Trigger/L1TMuonEndCap/interface/TrackFinder.hh
+++ b/L1Trigger/L1TMuonEndCap/interface/TrackFinder.hh
@@ -45,6 +45,8 @@ private:
   int verbose_;
 
   bool useCSC_, useRPC_, useGEM_;
+
+  std::string era_;
 };
 
 #endif

--- a/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -20,6 +20,9 @@ simEmtfDigisMC = cms.EDProducer("L1TMuonEndCapTrackProducer",
     RPCEnable = cms.bool(True),
     GEMEnable = cms.bool(False),
 
+    # Era (options: 'Run2_2016', 'Run2_2017')
+    Era = cms.string('Run2_2016'),
+
     # BX
     MinBX    = cms.int32(-3),
     MaxBX    = cms.int32(+3),


### PR DESCRIPTION
This PR changes the option "spPAversion" to "Era", which might be useful for other things in the future. The default is set to "Run2_2016", but can be changed easily.

It also fixes the compilation issue in TrackFinder.cc